### PR TITLE
add meta files for configs

### DIFF
--- a/Runtime/Input/Configs.meta
+++ b/Runtime/Input/Configs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d07584db42fa7c8458a018408fb4a039
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_knuckles.json.meta
+++ b/Runtime/Input/Configs/bindings_knuckles.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a7dd039215080b14bb1b3eab592ec789
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_controller.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_controller.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c9558143c233bd4488229704ef8a4850
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_camera.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_camera.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6de317e5c14d14049891ae1308874f8c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_chest.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_chest.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 267e387a0d167ad48a68a8b894314d37
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_handed.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_handed.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e577dfb53c5d9a746a600b23fd92c043
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_keyboard.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_keyboard.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0e6ce76001a94874db0b1bfc90fd5471
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_left_elbow.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_left_elbow.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f907de0c627e3b84fac3632a75f8253e
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_left_foot.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_left_foot.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7097d41bf9f2a6144a543f398296aed7
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_left_knee.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_left_knee.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e9cdfa0051a968447b4dde2c714bd43b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_left_shoulder.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_left_shoulder.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 68dee3fd1352bc5418bacddc8ab5c782
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_right_elbow.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_right_elbow.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6591483ce83c43d4ea616fc53f39d6a2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_right_foot.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_right_foot.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 726b6e2829684a545b21c5f364a13b20
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_right_knee.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_right_knee.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8e4193c2566c39b4385ac501b297d271
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_right_shoulder.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_right_shoulder.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4b281f450935cc14fb1aec5acdff9bce
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Configs/bindings_vive_tracker_waist.json.meta
+++ b/Runtime/Input/Configs/bindings_vive_tracker_waist.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32ecce9376b80494fb33629b0fe0d715
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Avoids (harmless but annoying) startup errors in Unity by adding .meta files for the folder run Runtime/Input/Configs and the files within.

Please consider to include into next release.